### PR TITLE
Simplify API `image` route handler

### DIFF
--- a/api/handlers/image.js
+++ b/api/handlers/image.js
@@ -159,15 +159,15 @@ module.exports = ()=> {
       }
       res.reply(req, res, next, row);
     } else if ( req.query.image_id === 'next_eqn_prediction') {
-        //TODO : this type should key into the stack_type column in the stack table instead of the stack_id like it does now
+      //TODO : this type should key into the stack_type column in the stack table instead of the stack_id like it does now
       type='prediction';
-      let where = 'WHERE true'
-      let params = []
-      where += "\nAND stack_type = $1"
-        params.push(type)
+      let whereStatement = 'WHERE true'
+      let params = {}
+      whereStatement += "\nAND stack_type = $(stack_type)"
+      params['stack_type'] = type
       if (req.query.stack_id) {
-          where += "\n AND stack_id = $2"
-        params.push(req.query.stack_id)
+        whereStatement += "\n AND stack_id = $(stack_id)"
+        params['stack_id'] = req.query.stack_id
       }
       // Make sure we only get images with phrases or tags
 
@@ -182,11 +182,12 @@ module.exports = ()=> {
          FROM image i
          JOIN image_stack istack USING (image_id)
          JOIN stack USING (stack_id)
-               JOIN equations.equation p
-               ON p.image_id = i.image_id
-               WHERE true
-               ORDER BY random()
-               LIMIT 1`);
+         JOIN equations.equation p
+         ON p.image_id = i.image_id
+         WHERE true
+         ORDER BY random()
+         LIMIT 1
+          ${whereStatement}`);
 
         if (!row) {
           return res.reply(req, res, next, []);

--- a/api/handlers/image.js
+++ b/api/handlers/image.js
@@ -67,9 +67,7 @@ module.exports = ()=> {
           JOIN annotation_stack USING (image_stack_id)
         )
         ${baseSelect}
-        ${buildWhereClause(mainFilters)}
-        ORDER BY random()
-        LIMIT 1`
+        ${buildWhereClause(mainFilters)}`
 
     } else if ( req.query.image_id === 'validate') {
 
@@ -84,9 +82,7 @@ module.exports = ()=> {
         ${baseSelect}
         JOIN image_tag it
         USING (image_stack_id)
-        ${buildWhereClause(filters)}
-        ORDER BY random()
-        LIMIT 1`;
+        ${buildWhereClause(filters)}`;
 
     } else if ( req.query.image_id === 'next_prediction') {
 
@@ -94,9 +90,7 @@ module.exports = ()=> {
 
       query = `
        ${baseSelect}
-       ${buildWhereClause(filters)}
-       ORDER BY random()
-       LIMIT 1`;
+       ${buildWhereClause(filters)}`;
 
     } else if ( req.query.image_id === 'next_eqn_prediction') {
       //TODO : this type should key into the stack_type column in the stack table instead of the stack_id like it does now
@@ -107,9 +101,7 @@ module.exports = ()=> {
         ${baseSelect}
         JOIN equations.equation p
           ON p.image_id = i.image_id
-        ${buildWhereClause(filters)}
-        ORDER BY random()
-        LIMIT 1`;
+        ${buildWhereClause(filters)}`;
 
     } else {
       // Reset parameters entirely
@@ -118,9 +110,10 @@ module.exports = ()=> {
       query = `
         ${baseSelect.replace("stack_id,", "array_agg(stack.stack_id) stack_ids,")}
         WHERE image_id = $(image_id)
-        GROUP BY image_id, doc_id, page_no, file_path, created
-        LIMIT 1`;
+        GROUP BY image_id, doc_id, page_no, file_path, created`;
     }
+
+    query += `ORDER BY random() LIMIT 1`
 
     let row = await db.one(query, params);
 

--- a/api/handlers/image.js
+++ b/api/handlers/image.js
@@ -70,7 +70,8 @@ module.exports = ()=> {
 
       await recordTaggingStarted(db, row.image_id);
 
-      res.reply(req, res, next, row);
+      if (!row) { row = [] }
+      return res.reply(req, res, next, row);
 
     } else if ( req.query.image_id === 'validate') {
       type='annotation';
@@ -97,11 +98,8 @@ module.exports = ()=> {
           ORDER BY random()
           LIMIT 1`, params);
 
-        if (!row) {
-          return res.reply(req, res, next, []);
-        } else {
-          return res.reply(req, res, next, row);
-        }
+        if (!row) { row = [] }
+        return res.reply(req, res, next, row);
 
         await recordTaggingStarted(db, row.image_id);
 
@@ -138,12 +136,12 @@ module.exports = ()=> {
                LIMIT 1`, params);
 
         if (!row) {
-          return res.reply(req, res, next, []);
-        } else {
-          return res.reply(req, res, next, row);
+          /* NOTE: it seems odd to return an array when a single object is returned
+            by the normal route */
+          row = [];
         }
-
         return res.reply(req, res, next, row);
+
       } catch(error) {
         console.log(error)
         return res.error(req, res, next, 'An internal error occurred', 500)
@@ -179,11 +177,8 @@ module.exports = ()=> {
          ORDER BY random()
          LIMIT 1`);
 
-        if (!row) {
-          return res.reply(req, res, next, []);
-        } else {
-          return res.reply(req, res, next, row);
-        }
+         if (!row) { row = [] }
+         return res.reply(req, res, next, row);
 
       } catch(error) {
         console.log(error)

--- a/api/handlers/image.js
+++ b/api/handlers/image.js
@@ -10,7 +10,7 @@ module.exports = ()=> {
       i.image_id,
       doc_id,
       page_no,
-      stack_id stack,
+      stack_id,
       file_path,
       i.created
     FROM image i
@@ -44,7 +44,7 @@ module.exports = ()=> {
            OR tag_start < now() - interval '5 minutes' )
           AND image_id NOT IN (SELECT image_id FROM annotated)
           AND stack_type = $${params.length + 1}
-          ${stackIdFilter} 
+          ${stackIdFilter}
         ORDER BY random()
         LIMIT 1`
          params.push(type)
@@ -103,7 +103,7 @@ module.exports = ()=> {
     } else if ( req.query.image_id === 'next_prediction') {
       type='prediction';
       let params = []
-      if (req.query.stack_name) { 
+      if (req.query.stack_name) {
           where = `\n WHERE stack_id = $${params.length + 1}`
           params.push(req.query.stack_name)
       } else {
@@ -117,7 +117,7 @@ module.exports = ()=> {
            i.image_id,
            i.doc_id,
            i.page_no,
-           stack_id stack,
+           stack_id,
            file_path,
            i.created
          FROM image i
@@ -144,7 +144,7 @@ module.exports = ()=> {
       let params = []
       where += "\nAND stack_type = $1"
         params.push(type)
-      if (req.query.stack_id) { 
+      if (req.query.stack_id) {
           where += "\n AND stack_id = $2"
         params.push(req.query.stack_id)
       }
@@ -155,7 +155,7 @@ module.exports = ()=> {
            i.image_id,
            i.doc_id,
            i.page_no,
-           stack_id stack,
+           stack_id,
            file_path,
            i.created
          FROM image i
@@ -181,7 +181,7 @@ module.exports = ()=> {
 
     } else {
       let row = await db.one(`
-        ${baseSelect.replace("stack_id stack", "array_agg(stack.stack_id) stacks")}
+        ${baseSelect.replace("stack_id,", "array_agg(stack.stack_id) stack_ids,")}
         WHERE image_id = $1
           GROUP BY image_id, doc_id, page_no, file_path, created
           LIMIT 1`,

--- a/api/handlers/image.js
+++ b/api/handlers/image.js
@@ -74,19 +74,19 @@ module.exports = ()=> {
       return res.reply(req, res, next, row);
 
     } else if ( req.query.image_id === 'validate') {
-      type='annotation';
       let where = 'WHERE true'
-      let params = []
+      let params = {
+        'stack_type': 'annotation'
+      };
       if (req.query.validated == false) {
         where = 'WHERE validator IS NULL'
       } else if (req.query.validated == true) {
         where = 'WHERE validator IS NOT NULL'
       }
-      where += "\nAND stack_type = $1"
-      params.push(type)
+      where += "\nAND stack_type = $(stack_type)"
       if (req.query.stack_id) {
-          where += "\nAND stack_id = $2"
-          params.push(req.query.stack_id)
+          where += "\nAND stack_id = $(stack_id)"
+          params['stack_id'] = req.query.stack_id
       }
 
       try {
@@ -135,11 +135,7 @@ module.exports = ()=> {
                ORDER BY random()
                LIMIT 1`, params);
 
-        if (!row) {
-          /* NOTE: it seems odd to return an array when a single object is returned
-            by the normal route */
-          row = [];
-        }
+        if (!row) { row = [] }
         return res.reply(req, res, next, row);
 
       } catch(error) {

--- a/api/handlers/image.js
+++ b/api/handlers/image.js
@@ -20,8 +20,8 @@ module.exports = ()=> {
   const baseSelect = `
     SELECT
       i.image_id,
-      doc_id,
-      page_no,
+      i.doc_id,
+      i.page_no,
       stack_id,
       file_path,
       i.created
@@ -109,19 +109,12 @@ module.exports = ()=> {
 
       params['stack_type'] = 'prediction';
       try {
-          let row = await db.one(`SELECT
-           i.image_id,
-           i.doc_id,
-           i.page_no,
-           stack_id,
-           file_path,
-           i.created
-         FROM image i
-         JOIN image_stack istack USING (image_id)
-         JOIN stack USING (stack_id)
-         ${buildWhereClause(filters)}
-         ORDER BY random()
-         LIMIT 1`, params);
+
+        let row = await db.one(`
+           ${baseSelect}
+           ${buildWhereClause(filters)}
+           ORDER BY random()
+           LIMIT 1`, params);
 
         if (!row) { row = [] }
         return res.reply(req, res, next, row);
@@ -138,21 +131,14 @@ module.exports = ()=> {
       // Make sure we only get images with phrases or tags
 
       try {
-        let row = await db.one(`SELECT
-           i.image_id,
-           i.doc_id,
-           i.page_no,
-           stack_id,
-           file_path,
-           i.created
-         FROM image i
-         JOIN image_stack istack USING (image_id)
-         JOIN stack USING (stack_id)
-         JOIN equations.equation p
-         ON p.image_id = i.image_id
-         ${buildWhereClause(filters)}
-         ORDER BY random()
-         LIMIT 1`);
+
+        let row = await db.one(`
+          ${baseSelect}
+          JOIN equations.equation p
+            ON p.image_id = i.image_id
+          ${buildWhereClause(filters)}
+          ORDER BY random()
+          LIMIT 1`);
 
          if (!row) { row = [] }
          return res.reply(req, res, next, row);

--- a/api/handlers/image.js
+++ b/api/handlers/image.js
@@ -24,13 +24,13 @@ module.exports = ()=> {
     /* This gets us the next ALREADY TAGGED image */
     if (req.query.image_id === 'next') {
       type='annotation';
-      if (req.query.stack_name) {
+      if (req.query.stack_id) {
           withStatement = `
             WITH annotation_stack AS (SELECT * FROM image_stack JOIN stack USING (stack_id) WHERE stack_type='annotation' AND stack_id=$${params.length + 1}),
              annotated AS (SELECT image_id FROM image_tag JOIN annotation_stack USING (image_stack_id))
              `
           stackIdFilter=`AND stack_id=$${params.length + 1}`
-          params.push(req.query.stack_name)
+          params.push(req.query.stack_id)
       } else {
           withStatement = `
         WITH annotation_stack AS (SELECT * FROM image_stack JOIN stack USING (stack_id) WHERE stack_type='annotation'),
@@ -69,9 +69,9 @@ module.exports = ()=> {
       }
       where += "\nAND stack_type = $1"
       params.push(type)
-      if (req.query.stack_name) {
+      if (req.query.stack_id) {
           where += "\nAND stack_id = $2"
-          params.push(req.query.stack_name)
+          params.push(req.query.stack_id)
       }
 
       try {
@@ -103,9 +103,9 @@ module.exports = ()=> {
     } else if ( req.query.image_id === 'next_prediction') {
       type='prediction';
       let params = []
-      if (req.query.stack_name) {
+      if (req.query.stack_id) {
           where = `\n WHERE stack_id = $${params.length + 1}`
-          params.push(req.query.stack_name)
+          params.push(req.query.stack_id)
       } else {
           where = 'WHERE true'
       }

--- a/api/handlers/image.js
+++ b/api/handlers/image.js
@@ -184,10 +184,9 @@ module.exports = ()=> {
          JOIN stack USING (stack_id)
          JOIN equations.equation p
          ON p.image_id = i.image_id
-         WHERE true
+         ${whereStatement}
          ORDER BY random()
-         LIMIT 1
-          ${whereStatement}`);
+         LIMIT 1`);
 
         if (!row) {
           return res.reply(req, res, next, []);

--- a/api/handlers/util.js
+++ b/api/handlers/util.js
@@ -7,6 +7,12 @@ const wrapHandler = handler => {
   }
 };
 
+const buildWhereClause = filters => {
+  if (!filters || filters.length == 0) return '';
+  return "WHERE "+filters.join("\n  AND ");
+}
+
 module.exports = {
-  wrapHandler
+  wrapHandler,
+  buildWhereClause
 };

--- a/api/v1-routes/image.js
+++ b/api/v1-routes/image.js
@@ -12,9 +12,9 @@ module.exports = {
       'type': 'boolean',
       'description': `When specifying 'next' or 'validate', will limit possible results to either images that have been validated at least once or images that have not been validated.`
     },
-    'stack_name':{
+    'stack_id':{
       'type': 'text',
-      'description': `Will filter the result to the requested 'stack' name. This allows distinction between different sets of annotations (or results). If not specified, the full collection is considered.`
+      'description': `Will filter the result to the requested 'stack_id'. This allows distinction between different sets of annotations (or results). If not specified, the full collection is considered.`
     }
   },
   requiredParameters: [ ],


### PR DESCRIPTION
We want to refactor the `image` route handler to simplify code and standardize names

- [x] Convert output fields named `stack` to `stack_id`
- [x] Change `stack_name` in API route handler, and change parameter name appropriately
- [x] Get rid of numbered parameter generation in favor of the simpler [named parameters](https://github.com/vitaly-t/pg-promise#named-parameters) syntax
- [x] Potentially, deduplicate generated SQL

This should be important to full implementation of #12 .
