### PR TITLE
Better multiword query handling.

### DIFF
--- a/frontend-shared/src/visualizer-app/knowledge-base/provider/query-string.ts
+++ b/frontend-shared/src/visualizer-app/knowledge-base/provider/query-string.ts
@@ -5,10 +5,15 @@ type Updater = (q: ParsedQuery<string | number>) => void;
 const useSearchString = (): [ParsedQuery<string | number>, Updater] => {
   const loc = useLocation();
   const history = useHistory();
-  const searchString = queryString.parse(loc.search, {
+  let searchString = queryString.parse(loc.search, {
     parseNumbers: true,
     arrayFormat: "comma",
   });
+
+  // Reassemble query string if we've parsed it into an array
+  if (Array.isArray(searchString.query)) {
+    searchString.query = searchString.query.join(",");
+  }
 
   const updateSearchString = (q) => {
     // Don't update the search string unless we actually have conducted a search


### PR DESCRIPTION
To date, we have fixed URL decoding for multiword queries so that they can be linked to. It might be nice to make the embedding models work correctly, either by rendering two separate sets of results (one for each word) or by automatically switching to bigram or trigram models...I don't have a clear idea of what to do here until we fix the API.

This partially addresses #75.